### PR TITLE
BUG: fixes sphinx directive for image source path on Windows

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -420,7 +420,7 @@ class EmbeddedSphinxShell(object):
         # as absolute path for Sphinx
         # sphinx expects a posix path, even on Windows
         posix_path = pathlib.Path(savefig_dir,filename).as_posix()
-        outfile = '/' + os.path.relpath(posix_path, source_dir)
+        outfile = '/' + pathlib.Path(os.path.relpath(posix_path, source_dir)).as_posix()
 
         imagerows = ['.. image:: %s' % outfile]
 


### PR DESCRIPTION
As stated in code comment, there is an issue with image path on windows, which the proposed solution on PR #11728 did not completely solved as `os.path.relpath` still returns system dependent separator.

Been using this solution for quite some time in my own machine and project. So I think this solves the image source path issue on Windows.